### PR TITLE
Re-style event cards

### DIFF
--- a/app/javascript/components/Events.jsx
+++ b/app/javascript/components/Events.jsx
@@ -16,8 +16,16 @@ const Events = ({events}) =>
           className='event-card'
         >
           <h2 className='event-title'>{event.name}</h2>
-          <p>{event.location}</p>
-          <p>Time: <span className='events__time'>{event.time ? event.time : 'TBD'}</span></p>
+          <div className='event-card-body'>
+            <div className='event-field event-card-info'>
+              <i className='fa fa-2x fa-map-marker event-card-map'></i>
+              { event.location }
+            </div>
+              <div className='event-field event-final-time event-card-info'>
+              <i className='fa fa-2x fa-clock-o event-card-clock'></i>
+               { event.time || 'TBD' }
+            </div>
+          </div>
         </a>
       )}
     </div>

--- a/app/javascript/styles/components/events.sass
+++ b/app/javascript/styles/components/events.sass
@@ -12,17 +12,33 @@
   @include hover-change($color--hilite)
 
 .events-container
-  align-items: center
   display: flex
-  flex-direction: column
+  flex-wrap: wrap
+  width: 80%
+  margin: auto
+  justify-content: space-around
 
 .event-card
   background: rgba($color--silver-chalice, 0.2)
   border-radius: 5px
   color: $color--mineshaft
-  min-width: 800px
+  width: fit-content
   margin: 25px
   padding: 0 0 15px
+
+.event-card-body
+  width: 75%
+  min-width: 325px
+  padding-left: 30%
+
+.event-card-info
+  text-align: left
+
+.event-card-map
+  padding: 0 20px 0 7px
+
+.event-card-clock
+  padding-right: 16px
 
 .event-title
   background: rgba($color--main, 0.8)


### PR DESCRIPTION
Cards now flow in rows that take up 80% of the browser width.

![screen shot 2017-11-14 at 10 19 07 pm](https://user-images.githubusercontent.com/17228243/32822264-8510cccc-c98c-11e7-9e6e-402442790168.png)


